### PR TITLE
feature: deploy subgraph in a hosted service

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "codegen": "./scripts/codegen.sh",
     "create": "./scripts/create.sh",
     "deploy": "./scripts/deploy.sh",
+    "hosted-service-deploy": "./scripts/hosted_service_deploy.sh",
     "start": "npm run codegen && npm run build && npm run create && npm run deploy",
     "prepare:xdai": "cp .env-xdai .env",
     "prepare:poa-sokol": "cp .env-poa-sokol .env"

--- a/scripts/hosted_service_deploy.sh
+++ b/scripts/hosted_service_deploy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+source "./scripts/common.sh"
+
+# Export environment variables
+export_env $1
+
+# Export subgraph version from package.json
+get_version
+
+# Prepare manifest
+build_manifest
+
+# Auth
+exec_graph auth "--product hosted-service"
+
+# Deploy graph
+exec_graph deploy "--product hosted-service $SUBGRAPH_NAME --version-label $SUBGRAPH_VERSION"
+
+# Cleanup
+clear_manifest


### PR DESCRIPTION
closes https://github.com/bootnodedev/circles-groups-safe-app/issues/25

## Description

This PR adds the following changes:
- a script file to be able to deploy to a hosted service in Subgraph

## How to test

Check deployed a new Hosted Service:
- https://thegraph.com/hosted-service/subgraph/laimejesus/circles-local

Used this SG as a reference:
- https://thegraph.com/hosted-service/subgraph/azf20/circles-ubi

![image](https://user-images.githubusercontent.com/13955827/170765518-85ed49b3-a4f2-4aee-a6b8-11f84f52fff5.png)

