### PR TITLE
[SG] adds handlers for the property update events for Groups

### DIFF
--- a/src/groupCurrencyToken.ts
+++ b/src/groupCurrencyToken.ts
@@ -7,7 +7,12 @@ import {
   GroupCurrencyTokenCreated as GroupCurrencyTokenCreatedEvent
 } from './types/GroupCurrencyTokenFactory/GroupCurrencyTokenFactory'
 import {
-  GroupCurrencyToken as GroupCurrencyTokenContract, MemberTokenAdded as MemberTokenAddedEvent
+  GroupCurrencyToken as GroupCurrencyTokenContract,
+  MemberTokenAdded as MemberTokenAddedEvent,
+  OnlyOwnerCanMint as OnlyOwnerCanMintEvent,
+  OnlyTrustedCanMint as OnlyTrustedCanMintEvent,
+  OwnerChanged as OwnerChangedEvent,
+  Suspended as SuspendedEvent,
 } from './types/GroupCurrencyTokenFactory/GroupCurrencyToken'
 import { GroupCurrencyToken, SafeGroupMember } from './types/schema'
 import { GroupCurrencyToken as GroupCurrencyTokenTemplate } from './types/templates'
@@ -77,4 +82,35 @@ export function handleMemberTokenRemoved(event: MemberTokenAddedEvent): void {
   let safeId = event.params._memberToken.toHex()
   let groupMemberId = createSafeGroupMemberId(groupId, safeId)
   store.remove('SafeGroupMember', groupMemberId)
+}
+
+export function handleOnlyOwnerCanMint(event: OnlyOwnerCanMintEvent): void {
+  let groupAddress = event.params._event.address
+  let onlyOwnerCanMint = event.params._onlyOwnerCanMint
+  let groupCurrencyToken = createGroupCurrencyTokenIfNonExistent(groupAddress)
+  groupCurrencyToken.onlyOwnerCanMint = onlyOwnerCanMint
+  groupCurrencyToken.save()
+}
+
+export function handleOnlyTrustedCanMint(event: OnlyTrustedCanMintEvent): void {
+  let groupAddress = event.params._event.address
+  let onlyTrustedCanMint = event.params._onlyTrustedCanMint
+  let groupCurrencyToken = createGroupCurrencyTokenIfNonExistent(groupAddress)
+  groupCurrencyToken.onlyTrustedCanMint = onlyTrustedCanMint
+  groupCurrencyToken.save()
+}
+export function handleOwnerChanged(event: OwnerChangedEvent): void {
+  let groupAddress = event.params._event.address
+  let newOwner = event.params._new
+  let groupCurrencyToken = createGroupCurrencyTokenIfNonExistent(groupAddress)
+  groupCurrencyToken.owner = newOwner.toHexString()
+  groupCurrencyToken.save()
+}
+export function handleSuspended(event: SuspendedEvent): void {
+  let groupAddress = event.params._event.address
+  let groupCurrencyToken = createGroupCurrencyTokenIfNonExistent(groupAddress)
+  // @TODO the suspended event only send the owner address data, it'd be better if send the suspended bool
+  let GroupCurrencyTokenContractInstance = GroupCurrencyTokenContract.bind(groupAddress)
+  groupCurrencyToken.suspended = GroupCurrencyTokenContractInstance.suspended()
+  groupCurrencyToken.save()
 }

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -139,3 +139,11 @@ templates:
           handler: handleMemberTokenAdded
         - event: MemberTokenRemoved(indexed address)
           handler: handleMemberTokenRemoved
+        - event: OnlyOwnerCanMint(indexed bool)
+          handler: handleOnlyOwnerCanMint
+        - event: OnlyTrustedCanMint(indexed bool)
+          handler: handleOnlyTrustedCanMint
+        - event: OwnerChanged(indexed address,indexed address)
+          handler: handleOwnerChanged
+        - event: Suspended(indexed address)
+          handler: handleSuspended


### PR DESCRIPTION
related [#39](https://github.com/BootNodeDev/circles-groups-safe-app/issues/39)

Check existing groups in: https://thegraph.com/hosted-service/subgraph/laimejesus/circles-local

## Description

This PR adds the following changes:
- adds handler for the property change events for GroupCurrencyToken
  - the events are OnlyOwnerCanMint, OnlyTrustedCanMint, OwnerChanged, Suspended

There is a possible improvement in the handler for the suspended event, if the event sends the latest suspended value

## How to test

- copy `.env-xdai.example` -> `.env`
- need to modify: ACCESS_TOKEN, SUBGRAPH_NAME, SUBGRAPH_NETWORK, START_BLOCK variables
- deploy subgraph: `npm run deploy hosted-service-deploy`
- check deployed service

## Example
Check deployed Subgraph in Hosted Service:
- https://thegraph.com/hosted-service/subgraph/laimejesus/circles-local

No examples atm


