### PR TITLE
[SG] adds handler for the minted event

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -115,6 +115,7 @@ type GroupCurrencyToken @entity {
   owner: String
   treasury: String
   mintFeePerThousand: BigInt
+  minted: BigInt!
   suspended: Boolean
   onlyOwnerCanMint: Boolean
   onlyTrustedCanMint: Boolean

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -147,3 +147,5 @@ templates:
           handler: handleOwnerChanged
         - event: Suspended(indexed address)
           handler: handleSuspended
+        - event: Minted(indexed address,uint256,uint256,uint256)
+          handler: handleMinted


### PR DESCRIPTION
related [#39](https://github.com/BootNodeDev/circles-groups-safe-app/issues/39)

Check existing groups in: https://thegraph.com/hosted-service/subgraph/laimejesus/circles-local

## Description

This PR adds the following changes:
- adds handler for minted event
- adds minted property to the GroupCurrencyToken entity

We might want to save the data from this event in a separate entity?

## How to test

- copy `.env-xdai.example` -> `.env`
- need to modify: ACCESS_TOKEN, SUBGRAPH_NAME, SUBGRAPH_NETWORK, START_BLOCK variables
- deploy subgraph: `npm run deploy hosted-service-deploy`
- check deployed service

## Example
Check deployed Subgraph in Hosted Service:
- https://thegraph.com/hosted-service/subgraph/laimejesus/circles-local

No examples ATM
