### PR TITLE
adds timestamp property for group currency schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -93,9 +93,8 @@ type OwnershipChange implements Event @entity {
 
 type GroupCreation implements Event @entity {
   id: ID! # Concatenation of block number and log ID
-  group: String
+  group: GroupCurrencyToken
   creator: String
-  name: String
 }
 
 type GroupMint implements Event @entity {
@@ -103,26 +102,26 @@ type GroupMint implements Event @entity {
   receiver: String
   amount: BigInt
   mintFee: BigInt
-  group: String
+  group: GroupCurrencyToken
 }
 
 type GroupOwnerChange implements Event @entity {
   id: ID! # Concatenation of block number and log ID
-  oldOwner: String
-  newOwner: BigInt
-  group: String
+  oldOwner: Safe
+  newOwner: Safe
+  group: GroupCurrencyToken
 }
 
 type GroupAddMember implements Event @entity {
   id: ID! # Concatenation of block number and log ID
-  user: String
-  group: String
+  user: Safe
+  group: GroupCurrencyToken
 }
 
 type GroupRemoveMember implements Event @entity {
   id: ID! # Concatenation of block number and log ID
-  user: String
-  group: String
+  user: Safe
+  group: GroupCurrencyToken
 }
 
 type Notification implements Event @entity {
@@ -160,6 +159,7 @@ type GroupCurrencyToken @entity {
   mintFeePerThousand: BigInt
   minted: BigInt!
   suspended: Boolean
+  time: BigInt!
   onlyOwnerCanMint: Boolean
   onlyTrustedCanMint: Boolean
   members: [SafeGroupMember!]! @derivedFrom(field: "group")

--- a/src/groupCurrencyToken.ts
+++ b/src/groupCurrencyToken.ts
@@ -64,6 +64,7 @@ export function handleGroupCurrencyTokenCreation(event: GroupCurrencyTokenCreate
   let groupAddress = event.params._address
   let creator = event.params._deployer.toHexString()
   let groupCurrencyToken = createGroupCurrencyTokenIfNonExistent(groupAddress)
+  groupCurrencyToken.time = event.block.timestamp
   groupCurrencyToken.creator = creator
   groupCurrencyToken.save()
 
@@ -72,7 +73,6 @@ export function handleGroupCurrencyTokenCreation(event: GroupCurrencyTokenCreate
   let groupCreationEvent = new GroupCreation(eventId)
   groupCreationEvent.creator = creator
   groupCreationEvent.group = groupCurrencyToken.id
-  groupCreationEvent.name = groupCurrencyToken.name
   groupCreationEvent.save()
 
   // Creates Notification for Group Creation event


### PR DESCRIPTION
### Description

This PR adds some missing information for the following schemas:
- group currency token:
  - timestamp: creation date
- Use relation instead of string address for these schemas:
  - GroupCreation
  - GroupMint
  - GroupAddMember
  - GroupRemoveMember

The creation date is needed for the UI to sort the groups by this attribute.
The group information is needed for the UI for the notification page

### Example

https://thegraph.com/hosted-service/subgraph/laimejesus/shisus-crc-local

Groups
![image](https://user-images.githubusercontent.com/13955827/184357917-b6429bab-c7dc-42ad-aa49-bb5b1325609f.png)

Notifications
![image](https://user-images.githubusercontent.com/13955827/184357862-44cba673-866d-48f3-ad32-d12ad4e01467.png)


