### PR TITLE
Feature/#210 group ownership change notification

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -107,8 +107,8 @@ type GroupMint implements Event @entity {
 
 type GroupOwnerChange implements Event @entity {
   id: ID! # Concatenation of block number and log ID
-  oldOwner: Safe
-  newOwner: Safe
+  oldOwner: String
+  newOwner: String
   group: GroupCurrencyToken
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -62,6 +62,7 @@ enum NotificationType {
   GROUP_ADD_MEMBER
   GROUP_REMOVE_MEMBER
   GROUP_MINT
+  GROUP_OWNER_CHANGE
 }
 
 type TrustChange implements Event @entity {


### PR DESCRIPTION
related [#210](https://github.com/BootNodeDev/circles-groups-safe-app/issues/210)

### Description

This PR adds the following changes:
- Fixes issue with the GroupOwnerChangeEvent schema, 
  - it was using Safe address when there are some cases that the owner address used is not a safe
- Adds notifications now are only created for existing safe accounts
- Fixes type 'GROUP_OWNER_CHANGE' was not added in the NotificationType enum, so it was not possible to filter by those notifications

### How to test

old SG: https://thegraph.com/hosted-service/subgraph/laimejesus/shisus-crc-local

new SG: https://thegraph.com/hosted-service/subgraph/laimejesus/circles-local

After fix:

![image](https://user-images.githubusercontent.com/13955827/187693445-0400799c-3fc2-4daa-aa39-a2220d36ee86.png)

